### PR TITLE
Call enable_in_context with params

### DIFF
--- a/lua/cmp-spell/init.lua
+++ b/lua/cmp-spell/init.lua
@@ -77,7 +77,7 @@ function source:complete(params, callback)
     local option = validate_option(params)
 
     local input = string.sub(params.context.cursor_before_line, params.offset)
-    if option.enable_in_context() then
+    if option.enable_in_context(params) then
         callback({ items = candidates(input, option), isIncomplete = true })
     else
         callback({ items = {}, isIncomplete = true })


### PR DESCRIPTION
Pass `params` to `enable_in_context` so it can use, e.g.,
`params.context.option.reason` to suppress only autocomplete in
certain contexts. Without `params.context` the reason is only accessible
via the hacky `require('cmp').core.context`, which might be subject to
data races because `core.context` is overwritten each time a completion
request is made to a source.
